### PR TITLE
go1.16 adds "module-aware mode by default"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 # Stage 1
 FROM golang:latest as builder
 
+# Turn off modules
+RUN go env -w GO111MODULE="off"
+
 # Copy in the go files 
 COPY . /go/src/produce_demo
 


### PR DESCRIPTION
Currently my project isn't designed to use modules (because I'm lazy) -
so I'm turning it off for the moment